### PR TITLE
Proof-of-concept: web-api-extension silent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Json Spec
 ===================
 
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/fesor/json_spec/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/fesor/json_spec/?branch=master) 
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/fesor/json_spec/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/fesor/json_spec/?branch=master)
 
 If you working with JSON-based REST APIs there are several issues:
 
@@ -105,7 +105,9 @@ default:
         JsonSpec\Behat\Extension:
 ```
 
-Also not that json_spec should have access to responses. To make it so, just implement ```JsonConsumerAware``` interface for your context:
+To make `json_spec` work, it should have access to response body. If you are using [behat/web-api-extension](https://github.com/Behat/WebApiExtension) then just check that `json_spec` extension is enabled somewhere after it and that's all. `json_spec` will wrap Guzzle and will remember every response to use it for getting JSON.
+
+If you are using your own context for interaction with server (Guzzle, curl, etc), then you need to implement JsonConsumerAware interface for your context:
 
 ```php
 use \JsonSpec\Behat\Context\JsonConsumerAware;
@@ -125,6 +127,17 @@ class MyRestApiFeatureContext implements Context, JsonConsumerAware
     {
         // ... make request and get response body as string
         $this->jsonConsumer->setJson($responseBody);
+    }
+
+    /**
+     * @afterScenario
+     */
+    public function tearDown()
+    {
+        // we need to clear data ofter each scenario
+        // if you need several responses in one scenario
+        // then you can always use memoization
+        $this->jsonConsumer->clear();
     }
 }
 ```

--- a/src/Behat/Consumer/JsonConsumer.php
+++ b/src/Behat/Consumer/JsonConsumer.php
@@ -29,4 +29,21 @@ class JsonConsumer implements JsonProvider
         return $this->lastJson;
     }
 
+
+    /**
+     * @inheritdoc
+     */
+    public function clear()
+    {
+        $this->lastJson = null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPriority()
+    {
+        return 50;
+    }
+
 }

--- a/src/Behat/Context/Initializer/JsonSpecContextInitializer.php
+++ b/src/Behat/Context/Initializer/JsonSpecContextInitializer.php
@@ -6,6 +6,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Context\Initializer\ContextInitializer;
 use JsonSpec\Behat\Context\JsonSpecContext;
 use JsonSpec\Behat\Provider\JsonProvider;
+use JsonSpec\Behat\Provider\JsonProviderVoter;
 use JsonSpec\Helper\FileHelper;
 use JsonSpec\Helper\JsonHelper;
 use JsonSpec\Helper\MemoryHelper;
@@ -35,19 +36,19 @@ class JsonSpecContextInitializer implements ContextInitializer
     private $memoryHelper;
 
     /**
-     * @var JsonProvider
+     * @var JsonProviderVoter
      */
     private $jsonProvider;
 
     /**
-     * @param JsonProvider    $jsonProvider
+     * @param JsonProviderVoter    $jsonProvider
      * @param JsonSpecMatcher $matcher
      * @param JsonHelper      $jsonHelper
      * @param FileHelper      $fileHelper
      * @param MemoryHelper    $memoryHelper
      */
     public function __construct(
-        JsonProvider $jsonProvider,
+        JsonProviderVoter $jsonProvider,
         JsonSpecMatcher $matcher,
         JsonHelper $jsonHelper,
         FileHelper $fileHelper,

--- a/src/Behat/Context/JsonSpecContext.php
+++ b/src/Behat/Context/JsonSpecContext.php
@@ -6,6 +6,7 @@ use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use JsonSpec\Behat\Provider\JsonProvider;
+use JsonSpec\Behat\Provider\JsonProviderVoter;
 use JsonSpec\Helper\FileHelper;
 use JsonSpec\Helper\JsonHelper;
 use JsonSpec\Helper\MemoryHelper;
@@ -24,7 +25,7 @@ class JsonSpecContext implements Context
     private $memoryHelper;
 
     /**
-     * @var JsonProvider
+     * @var JsonProviderVoter
      */
     private $jsonProvider;
 
@@ -44,14 +45,14 @@ class JsonSpecContext implements Context
     private $fileHelper;
 
     /**
-     * @param JsonProvider    $jsonProvider
+     * @param JsonProviderVoter    $jsonProvider
      * @param JsonSpecMatcher $matcher
      * @param MemoryHelper    $memoryHelper
      * @param FileHelper      $fileHelper
      * @param JsonHelper      $jsonHelper
      */
     public function init(
-        JsonProvider $jsonProvider,
+        JsonProviderVoter $jsonProvider,
         JsonSpecMatcher $matcher,
         MemoryHelper $memoryHelper,
         FileHelper $fileHelper,

--- a/src/Behat/Extension.php
+++ b/src/Behat/Extension.php
@@ -6,12 +6,17 @@ use Behat\Behat\Context\ServiceContainer\ContextExtension;
 use \Behat\Testwork\ServiceContainer\Extension as BehatExtension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\DependencyInjection\Compiler\Compiler;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 class Extension implements BehatExtension
 {
+
+    const JSON_PROVIDER_TAG = 'json_spec.json_provider';
+
+    private $webApiExtensionClassname;
 
     /**
      * @inheritdoc
@@ -47,14 +52,22 @@ class Extension implements BehatExtension
         $container->setParameter('json_spec.json_directory', $config['json_directory']);
 
         $this->registerHelpers($container);
+        $this->provideWebApiIntegration($container);
         $this->registerJsonProvider($container);
+        $this->registerJsonProviderVoter($container);
         $this->registerContextInitializers($container);
     }
 
     /**
      * @inheritdoc
      */
-    public function initialize(ExtensionManager $extensionManager) {}
+    public function initialize(ExtensionManager $extensionManager)
+    {
+        $webApiExtension = $extensionManager->getExtension('web_api');
+        if (is_object($webApiExtension)) {
+            $this->webApiExtensionClassname = get_class($webApiExtension);
+        }
+    }
 
     /**
      * @inheritdoc
@@ -100,7 +113,8 @@ class Extension implements BehatExtension
     private function registerJsonProvider(ContainerBuilder $container)
     {
         $definition = new Definition('JsonSpec\\Behat\\Consumer\\JsonConsumer');
-        $container->setDefinition('json_spec.provider.json_provider', $definition);
+        $definition->addTag(static::JSON_PROVIDER_TAG);
+        $container->setDefinition('json_spec.provider.json_provider.manual', $definition);
     }
 
     /**
@@ -109,13 +123,13 @@ class Extension implements BehatExtension
     private function registerContextInitializers(ContainerBuilder $container)
     {
         $definition = new Definition('JsonSpec\\Behat\\Context\\Initializer\\JsonConsumerAwareInitializer', array(
-            new Reference('json_spec.provider.json_provider'),
+            new Reference('json_spec.provider.json_provider.manual'),
         ));
         $definition->addTag(ContextExtension::INITIALIZER_TAG);
         $container->setDefinition('json_spec.json_consumer_aware_initializer', $definition);
 
         $definition = new Definition('JsonSpec\\Behat\\Context\\Initializer\\JsonSpecContextInitializer', array(
-            new Reference('json_spec.provider.json_provider'),
+            new Reference('json_spec.json_provider_voter'),
             new Reference('json_spec.matcher'),
             new Reference('json_spec.helper.json_helper'),
             new Reference('json_spec.helper.file_helper'),
@@ -123,6 +137,62 @@ class Extension implements BehatExtension
         ));
         $definition->addTag(ContextExtension::INITIALIZER_TAG);
         $container->setDefinition('json_spec.context_initializer', $definition);
+    }
+
+    private function provideWebApiIntegration(ContainerBuilder $container)
+    {
+        if (!$this->webApiExtensionClassname) {
+            echo "No web api for integrate";
+            return;
+        }
+
+        $webApiExtensionReflection = new \ReflectionClass($this->webApiExtensionClassname);
+        if (!$webApiExtensionReflection->hasConstant('CLIENT_ID')) {
+            echo "web api extension doesnt have CLIENT_ID constant";
+            return;
+        }
+
+        $definitionName = $webApiExtensionReflection->getConstant('CLIENT_ID');
+
+        if (!$container->hasDefinition($definitionName)) {
+            // json_spec should be initialized after web_api
+            return;
+        }
+
+        // rename definition
+        $originalDefinition = $container->getDefinition($definitionName);
+        $originalDefinitionName = $definitionName.'.original';
+        $container->setDefinition($originalDefinitionName, $originalDefinition);
+
+        // provide wrapped Guzzle/Client
+        $wrappedClientDefinition = new Definition(
+            'JsonSpec\\Behat\\Wrapper\\GuzzleClient', array(
+                new Reference($originalDefinitionName)
+            )
+        );
+        $container->setDefinition($definitionName, $wrappedClientDefinition);
+        $webApiJsonProviderDefinition = new Definition(
+            'JsonSpec\\Behat\Provider\WebApiProvider',
+            array(
+                new Reference($definitionName)
+            )
+        );
+        $webApiJsonProviderDefinition->addTag(static::JSON_PROVIDER_TAG);
+        $container->setDefinition('json_spec.provider.json_provider.web_api', $webApiJsonProviderDefinition);
+    }
+
+    private function registerJsonProviderVoter(ContainerBuilder $container)
+    {
+        /** @var Definition[] $taggedServices */
+        $taggedServiceIds = $container->findTaggedServiceIds(static::JSON_PROVIDER_TAG);
+        $definition = new Definition('JsonSpec\\Behat\\Provider\\JsonProviderVoter');
+        foreach ($taggedServiceIds as $id=>$attributes) {
+            $definition->addMethodCall('addProvider', array(
+                new Reference($id)
+            ));
+        }
+
+        $container->setDefinition('json_spec.json_provider_voter', $definition);
     }
 
 }

--- a/src/Behat/Provider/JsonProvider.php
+++ b/src/Behat/Provider/JsonProvider.php
@@ -16,4 +16,16 @@ interface JsonProvider
      */
     public function getJson();
 
+    /**
+     * Returns priority of provider
+     *
+     * @return integer
+     */
+    public function getPriority();
+
+    /**
+     * Clears last used json
+     */
+    public function clear();
+
 }

--- a/src/Behat/Provider/JsonProviderVoter.php
+++ b/src/Behat/Provider/JsonProviderVoter.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace JsonSpec\Behat\Provider;
+
+class JsonProviderVoter
+{
+
+    /**
+     * @var JsonProvider[]
+     */
+    private $jsonProviders;
+
+    function __construct()
+    {
+        $this->jsonProviders = [];
+    }
+
+    /**
+     * @return string
+     */
+    public function getJson()
+    {
+        foreach($this->jsonProviders as $provider) {
+            $json = $provider->getJson();
+            if (!empty($json)) {
+                return $json;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Clear all data in all providers
+     */
+    public function clear()
+    {
+        foreach($this->jsonProviders as $provider) {
+            $provider->clear();
+        }
+    }
+
+    public function addProvider(JsonProvider $provider)
+    {
+        $this->jsonProviders[] = $provider;
+        usort($this->jsonProviders, function (JsonProvider $a, JsonProvider $b) {
+            return $a->getPriority() - $b->getPriority();
+        });
+    }
+
+}

--- a/src/Behat/Provider/WebApiProvider.php
+++ b/src/Behat/Provider/WebApiProvider.php
@@ -17,9 +17,14 @@ class WebApiProvider implements JsonProvider
     private $client;
 
     /**
+     * @var string
+     */
+    private $currentJson;
+
+    /**
      * @param GuzzleClient $client
      */
-    public function __constructor(GuzzleClient $client)
+    public function __construct(GuzzleClient $client)
     {
         $this->client = $client;
     }
@@ -29,7 +34,32 @@ class WebApiProvider implements JsonProvider
      */
     public function getJson()
     {
-        return (string) $this->client->getLastResponse()->getBody()->getContents();
+        if (empty($this->currentJson)) {
+            $lastResponse = $this->client->getLastResponse();
+            if ($lastResponse) {
+                $this->currentJson = (string) $this->client->getLastResponse()->getBody();
+            } else {
+                $this->currentJson = '';
+            }
+        }
+        return $this->currentJson;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function clear()
+    {
+        $this->currentJson = '';
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    public function getPriority()
+    {
+        return 10;
     }
 
 }

--- a/src/Behat/Wrapper/GuzzleClient.php
+++ b/src/Behat/Wrapper/GuzzleClient.php
@@ -2,8 +2,9 @@
 
 namespace JsonSpec\Behat\Wrapper;
 
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Message\RequestInterface;
+use GuzzleHttp\Message\Response;
 use GuzzleHttp\Message\ResponseInterface;
 
 /**
@@ -13,27 +14,159 @@ use GuzzleHttp\Message\ResponseInterface;
  * Class GuzzleClient
  * @package JsonSpec\Behat\Wrapper
  */
-class GuzzleClient extends Client
+class GuzzleClient implements ClientInterface
 {
+
+    /**
+     * @var ClientInterface
+     */
+    private $client;
 
     /**
      * @var ResponseInterface
      */
     private $lastResponse;
 
+
+    public function __construct(ClientInterface $client)
+    {
+        $this->client = $client;
+    }
+
     /**
-     * @return ResponseInterface
+     * @return ResponseInterface|null
      */
     public function getLastResponse()
     {
         return $this->lastResponse;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function send(RequestInterface $request)
     {
-        $this->lastResponse = parent::send($request);
-
-        return $this->lastResponse;
+        return $this->rememberResponse($this->client->send($request));
     }
+
+
+    /**
+     * @inheritdoc
+     */
+    public function createRequest($method, $url = null, array $options = [])
+    {
+        return $this->client->createRequest($method, $url, $options);
+    }
+
+    /**
+     * @inheritdoc
+     */
+
+    public function get($url = null, $options = [])
+    {
+        return $this->rememberResponse($this->client->get($url, $options));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function head($url = null, array $options = [])
+    {
+        // json_spec doesn't support HEAD requests
+        return $this->client->get($url, $options);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function delete($url = null, array $options = [])
+    {
+        return $this->rememberResponse($this->client->get($url, $options));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function put($url = null, array $options = [])
+    {
+        return $this->rememberResponse($this->client->get($url, $options));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function patch($url = null, array $options = [])
+    {
+        return $this->rememberResponse($this->client->patch($url, $options));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function post($url = null, array $options = [])
+    {
+        return $this->rememberResponse($this->client->post($url, $options));
+    }
+
+    /**
+     * @inheritdoc
+     */
+
+    public function options($url = null, array $options = [])
+    {
+        // json_spec doesn't support OPTIONS requests
+        return $this->client->options($url, $options);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function sendAll($requests, array $options = [])
+    {
+        // json_spec doesn't support multiple response processing
+        return $this->client->sendAll($requests, $options);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDefaultOption($keyOrPath = null)
+    {
+        $this->client->getDefaultOption($keyOrPath);
+    }
+
+    /**
+     * @inheritdoc
+     */
+
+    public function setDefaultOption($keyOrPath, $value)
+    {
+        return $this->client->getDefaultOption($keyOrPath, $value);
+    }
+
+    /**
+     * @inheritdoc
+     */
+
+    public function getBaseUrl()
+    {
+        return $this->client->getBaseUrl();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getEmitter()
+    {
+        return $this->client->getEmitter();
+    }
+
+    private function rememberResponse(Response $response)
+    {
+        $this->lastResponse = $response;
+
+        return $response;
+    }
+
 
 }


### PR DESCRIPTION
For those who use [web-api-extension](https://github.com/Behat/WebApiExtension) it's not so easy to use `json_spec`. @tyx provided his proof-of-concept to integrate `WebApiContext` with `json context`: https://github.com/tyx/WebApiExtension/commit/58d832a2be924b418ca2c188c57d340c6877b8d1 but i don't like the idea of extending context to use it with another.

Solution: use wrapped Guzzle/Client to get last response.
