### PR TITLE
Set base path for hasKeys step

### DIFF
--- a/features/common.feature
+++ b/features/common.feature
@@ -1,0 +1,36 @@
+Feature: Common actions
+
+  Background:
+    Given the JSON is:
+    """
+    {
+      "array": [
+        "json",
+        "spec"
+      ],
+      "created_at": "2011-07-08 02:27:34",
+      "empty_array": [
+
+      ],
+      "empty_hash": {
+      },
+      "false": false,
+      "float": 10.0,
+      "hash": {
+        "json": "spec"
+      },
+      "id": 1,
+      "integer": 10,
+      "negative": -10,
+      "null": null,
+      "string": "json_spec",
+      "true": true,
+      "updated_at": "2011-07-08 02:28:50"
+    }
+    """
+
+  Scenario: Mix formats
+    When I get the JSON
+    Then the JSON at "created_at" should be "2011-07-08 02:27:34"
+    And the JSON should have the following:
+      | hash/json |

--- a/src/Behat/Context/JsonSpecContext.php
+++ b/src/Behat/Context/JsonSpecContext.php
@@ -143,6 +143,8 @@ class JsonSpecContext implements Context
             $this->memoryHelper->remember($this->jsonProvider->getJson()),
             $base
         );
+        $this->matcher->getOptions()->atPath($base);
+
         foreach ($table->getRows() as $row) {
             if (count ($row) == 2) {
                 $this->checkEqualityInline(ltrim($base . '/' .$row[0], '/'), false, $row[1]);


### PR DESCRIPTION
Sometimes base path from previous steps overrides (or appends) base path for next step

``` gherkin
Then the JSON at "created_at" should be "2011-07-08 02:27:34"
And the JSON should have the following:
  | hash/json |
```

In this case is set wrong path for matching: created_at/hash/json
